### PR TITLE
Fix error in AMD/RequireJS module detection logic, preventing window.pttJPEG assignment 

### DIFF
--- a/pttjpeg.js
+++ b/pttjpeg.js
@@ -1277,7 +1277,7 @@
         } catch (e) {
             DEBUGMSG(sprintf("Caught exception: %s", e));
         }
-    } else if (typeof define != undefined && define.amd) {          //  Loaded with AMD /
+    } else if (typeof define != 'undefined' && define.amd) {          //  Loaded with AMD /
                                                                     //  RequireJS.
         define([], function() { return PTTJPEG; });
     } else if (typeof window != 'undefined') {                      //  Inside a regular web page,


### PR DESCRIPTION
AMD detection was breaking due to unquoted `undefined` value test.

This was preventing non-webworker browser use, as `window.pttJPEG` was never defined.